### PR TITLE
Remove unnecessary ozone ifdefs in native window views

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -504,15 +504,11 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
 
 #if defined(OS_LINUX)
 void NativeWindowViews::Maximize() {
-#if defined(USE_OZONE)
-  NOTIMPLEMENTED();
-#else
   if (IsVisible())
     widget()->Maximize();
   else
     widget()->native_widget_private()->Show(ui::SHOW_STATE_MAXIMIZED,
                                             gfx::Rect());
-#endif
 }
 #endif
 
@@ -823,12 +819,7 @@ bool NativeWindowViews::IsClosable() {
   }
   return !(info.fState & MFS_DISABLED);
 #elif defined(OS_LINUX)
-#if defined(USE_OZONE)
-  NOTIMPLEMENTED();
-  return false;
-#else
   return true;
-#endif
 #endif
 }
 
@@ -1397,12 +1388,7 @@ bool NativeWindowViews::CanMinimize() const {
 #if defined(OS_WIN)
   return minimizable_;
 #elif defined(OS_LINUX)
-#if defined(USE_OZONE)
-  NOTIMPLEMENTED();
-  return false;
-#else
   return true;
-#endif
 #endif
 }
 


### PR DESCRIPTION
### Windows not closing [[source](https://aur.archlinux.org/packages/electron-ozone/#pinned-724449)]

This pull-request should fix the issues related to windows not getting closed properly.

### Windows not opening

> Most often the symptom is that windows don't appear. [[source](https://github.com/electron/electron/issues/10915#issuecomment-671276987)]

> run `electron-9 --ozone-platform=wayland` but the window don't appear. `electron-9 --ozone-platform=x11` works without problem [[source](https://github.com/electron/electron/issues/10915#issuecomment-674009421)] 

I managed to trace this issue back to [this chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/2207172) which is part of Chromium 85 and Electron 10.

Rebasing your Ozone patches on top of Electron 10 (which includes the above CL) seems to fix this problem too (e.g.: windows not opening).

I've been running VSCode on top of Electron 10 with the Ozone patches for a few days and the only issues I've found so far were:
- drag-and-drop not working (this seems to be broken in Chromium 85 too so I don't think it's specific to Electron)
- crashes when opening GTK dialogs (e.g.: `File -> Open File...`)
I couldn't reproduce these crashes in a new Electron project so they may be VSCode specific

Other than that it works pretty great and unless you plan to do it yourself I was considering starting the process of upstreaming these changes to Electron.